### PR TITLE
Adding missing VectorArgMin/Max typedefs

### DIFF
--- a/FrameLib_Objects/Vector/FrameLib_Vector_Objects.h
+++ b/FrameLib_Objects/Vector/FrameLib_Vector_Objects.h
@@ -39,6 +39,7 @@ typedef FrameLib_Vector<statKurtosis>           FrameLib_Kurtosis;
 typedef FrameLib_Vector<statFlatness>           FrameLib_Flatness;
 typedef FrameLib_Vector<statRMS>                FrameLib_RMS;
 typedef FrameLib_Vector<statCrest>              FrameLib_Crest;
-
+typedef FrameLib_Vector<statArgMax>             FrameLib_VectorArgMax;
+typedef FrameLib_Vector<statArgMin>             FrameLib_VectorArgMin;
 
 #endif


### PR DESCRIPTION
These seemed to be missing from the `FrameLib_Vector_Objects.h` in the main repo