### PR TITLE
Rename argsAllInputs to argsMode, fix distribute mode to include offs…

### DIFF
--- a/FrameLib_Max_Objects/Common/FrameLib_MaxClass.h
+++ b/FrameLib_Max_Objects/Common/FrameLib_MaxClass.h
@@ -456,7 +456,7 @@ private:
 
 enum MaxObjectArgsMode {kAsParams, kAllInputs, kDistribute};
 
-template <class T, MaxObjectArgsMode argsSetAllInputs = kAsParams> class FrameLib_MaxClass : public MaxClass_Base
+template <class T, MaxObjectArgsMode argsMode = kAsParams> class FrameLib_MaxClass : public MaxClass_Base
 {
     typedef FrameLib_Object<FrameLib_MultiChannel>::Connection FrameLibConnection;
     typedef FrameLib_Object<t_object>::Connection MaxConnection;
@@ -467,7 +467,7 @@ public:
     
     // Class Initialisation (must explicitly give U for classes that inherit from FrameLib_MaxClass<>)
     
-    template <class U = FrameLib_MaxClass<T, argsSetAllInputs> > static void makeClass(t_symbol *nameSpace, const char *className)
+    template <class U = FrameLib_MaxClass<T, argsMode> > static void makeClass(t_symbol *nameSpace, const char *className)
     {
         // If handles audio/scheduler then make wrapper class and name the inner object differently..
         
@@ -649,9 +649,9 @@ public:
         if (flags & kInfoInputs)
         {
             object_post(mUserObject, "--- Input List ---");
-            if (argsSetAllInputs == kAllInputs)
+            if (argsMode == kAllInputs)
                 object_post(mUserObject, "N.B. - arguments set the fixed array values for all inputs.");
-            if (argsSetAllInputs == kDistribute)
+            if (argsMode == kDistribute)
                 object_post(mUserObject, "N.B - arguments are distributed one per input.");
             for (long i = 0; i < mObject->getNumAudioIns(); i++)
                 object_post(mUserObject, "Audio Input %ld: %s", i + 1, mObject->audioInfo(i, verbose).c_str());
@@ -698,7 +698,7 @@ public:
                 
                 if (verbose)
                 {
-                    if (argsSetAllInputs == kAsParams && params->getArgumentIdx(i) >= 0)
+                    if (argsMode == kAsParams && params->getArgumentIdx(i) >= 0)
                         object_post(mUserObject, "- Argument: %ld", params->getArgumentIdx(i) + 1);
                     if (numericType == FrameLib_Parameters::kNumericInteger || numericType == FrameLib_Parameters::kNumericDouble)
                     {
@@ -1256,7 +1256,7 @@ private:
             if (isTag(argv + i))
                 break;
             
-            if (argsSetAllInputs == kAsParams)
+            if (argsMode == kAsParams)
             {
                 char argNames[64];
                 sprintf(argNames, "%ld", i);
@@ -1330,18 +1330,18 @@ private:
         
         // Parse arguments if used to set inputs
         
-        if (argsSetAllInputs == kAllInputs || argsSetAllInputs == kDistribute)
+        if (argsMode == kAllInputs || argsMode == kDistribute)
         {
             i = parseNumericalList(values, argv, argc, 0);
-            if(argsSetAllInputs == kAllInputs)
+            if(argsMode == kAllInputs)
             {
                 for (unsigned long j = 0; i && j < getNumIns(); j++)
                     mObject->setFixedInput(j, &values[0], values.size());
             }
             else
             {
-                for (unsigned long j = 0; j < i && j < getNumIns(); j++)
-                    mObject->setFixedInput(j, &values[j], 1);
+                for (unsigned long j = 0; j < i && (j+1) < getNumIns(); j++)
+                    mObject->setFixedInput(j+1, &values[j], 1);
             }
         }
         


### PR DESCRIPTION
…et to 2nd inlets onwards so that parameters turn up where expected.

This makes clip, fold, wrap actually work when setting args in the max box. The problem was that the args were being associated with the 0th and 1st inputs, not the 1st and 2nd. 

Also renaming the template argument argsSetAllInputs to something better, which I thought I'd already done, but no. 