### PR TITLE
Add default case to switch, to make compiler happy

### DIFF
--- a/FrameLib_Objects/Ternary/FrameLib_TernaryTemplate.h
+++ b/FrameLib_Objects/Ternary/FrameLib_TernaryTemplate.h
@@ -26,12 +26,12 @@ template <typename Op> class FrameLib_TernaryOp : public FrameLib_Processor
         EnlargedInput(FrameLib_TernaryOp *owner, const double *input, unsigned long size, unsigned long extendedSize,
                       MismatchModes mode) : mOwner(owner),mAllocated(NULL)
         {
-            if(extendedSize > size)
+            if (extendedSize > size)
             {
                 mAllocated = owner->alloc<double>(extendedSize);
                 if(mAllocated)
                 {
-                    switch(mode)
+                    switch (mode)
                     {
                         case kWrap:
                         {
@@ -40,6 +40,7 @@ template <typename Op> class FrameLib_TernaryOp : public FrameLib_Processor
                         }
                         case kExtend:
                             enlargeExtend(mAllocated, input, size, extendedSize);
+                        default: break;
                     }
                     mPtr = mAllocated;
                 }


### PR DESCRIPTION
Change the template for fold, wrap, clip to stop warnings about unaccounted for case in switch block 