### PR TITLE
Implemented fix for incorrect convolution/correlation values

### DIFF
--- a/FrameLib_Dependencies/SpectralFunctions.hpp
+++ b/FrameLib_Dependencies/SpectralFunctions.hpp
@@ -267,8 +267,9 @@ namespace impl
         template<class T>
         void operator()(T& r_out, T& i_out, const T& a, const T& b, const T& c, const T& d, const T& scale, uintptr_t i)
         {
-            r_out = scale * (a * c + b * d);
+			T temp = scale * (a * c + b * d);
             i_out = scale * (b * c - a * d);
+			r_out = temp;
         }
     };
     
@@ -277,9 +278,10 @@ namespace impl
         template<class T>
         void operator()(T& r_out, T& i_out, const T& a, const T& b, const T& c, const T& d, const T& scale, uintptr_t i)
         {
-            r_out = scale * (a * c - b * d);
+			T temp = scale * (a * c - b * d);
             i_out = scale * (a * d + b * c);
-        }
+			r_out = temp;
+		}
     };
     
     template <typename Split>


### PR DESCRIPTION
Bug arises from the overwriting of the variable 'a' when both the input array and the output array pointers point to the same memory. This causes 'a' to be updated when calculating r_out, creating erroneous results when i_out is subsequently calculated. Fix adds a temporary variable so that both values are calculated before updating the output.